### PR TITLE
Start the winner count at 0

### DIFF
--- a/mods/pk/lib_mount/init.lua
+++ b/mods/pk/lib_mount/init.lua
@@ -22,7 +22,7 @@
 
 lib_mount = {
 	passengers = { },
-	win_count = 1
+	win_count = 0
 }
 
 local modname = minetest.get_current_modname()


### PR DESCRIPTION
Things added/changed:

- Start the winner count at 0.
  - This could prevent various winner count bugs as well as A.I. bugs once they're implemented.
